### PR TITLE
Fix for running out of memory when trying to do fasta_to_tree with too many fasta files

### DIFF
--- a/make.R
+++ b/make.R
@@ -52,6 +52,10 @@ my_i_value <- 2
 # Vector of reference genomes to use for making masked blast db
 genomes <- c("arabidopsis", "azolla", "salvinia")
 
+# Set number of subfolders for splitting fasta clusters
+n_cluster_subfolders <- 1000
+cluster_subfolders <- glue::glue(here("03_clusters_split/{1:n_cluster_subfolders}"))
+
 ### Load plans
 source("R/example_data.R")
 source("R/main_plan.R")


### PR DESCRIPTION
Solution is to split cluster fastas into subfolders before making trees, then combine again when done